### PR TITLE
Change Postman link

### DIFF
--- a/content-list/useful.md
+++ b/content-list/useful.md
@@ -19,7 +19,7 @@
 
 ## Programming
 - [GitHub Cheat Sheet](https://education.github.com/git-cheat-sheet-education.pdf)
-- [Postman](https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop?hl=en) - Chrome app for API testing 
+- [Postman](https://www.getpostman.com/) - Mac/Windows/Linux/Chrome app for API testing 
 - [Tota11y](https://khan.github.io/tota11y/) - Accessibility browser applet
 
 ### For Kids 


### PR DESCRIPTION
Since Google is retiring Chrome apps for non-Chrome OS devices,
change the link to point to Postman's site rather than the Chrome
store.

I would just bug you on Twitter about this, but this feels infinitely more geeky.